### PR TITLE
Prevent Slowing due to health percentage

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -15308,7 +15308,10 @@ void Unit::UpdateSpeed(UnitMoveType mtype, bool forced)
         && !IsPet()
         && !(IsControlledByPlayer() && IsVehicle())
         && !(creature->HasMechanicTemplateImmunity(MECHANIC_SNARE))
-        && !(creature->IsDungeonBoss()))
+        && !(creature->IsDungeonBoss())
+        //npcbots: prevent slowing due to health percentage
+        && !creature->IsNPCBot())
+        //end npcbot
     {
         // 1.6% for each % under 30.
         // use min(0, health-30) so that we don't boost mobs above 30.


### PR DESCRIPTION
I've noticed wandering bots slow down if their health is low, much like normal creatures, so I thought it might be good to add an exception to make them more player-like.

## Changes Proposed:
This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).

## Issues Addressed:
- Closes # (issue number)

## SOURCE:
The behavior of NPC bots not slowing down at low health is more aligned with player characters and enhances the player-like behavior of bots. This change is based on observational evidence from gameplay and aims to improve the immersion and consistency of NPC bot behavior.

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.

The changes have been tested on a local server running the latest version of AzerothCore. The testing involved observing the movement speed of Wandering bots at various health levels to ensure that they no longer slow down when their health is below 30%.

## How to Test the Changes:

1. Find an Wandering bot in the game.
2. Reduce the bot's health below 30% without killing it.
3. Observe the bot's movement speed to ensure it does not decrease due to low health.
4. Compare the bot's movement speed at low health to its speed at higher health levels to confirm there is no reduction.
