### PR TITLE
feat(NpcBots/bot_ai): Change ranged bots to run to a tank or to their master when they have aggro

### DIFF
--- a/src/server/game/AI/NpcBots/bot_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_ai.cpp
@@ -5430,7 +5430,24 @@ void bot_ai::CalculateAttackPos(Unit* target, Position& pos, bool& force) const
         force = true;
         return;
     }
+    
+    // Ranged bots that are being targeted should move towards a tank bot or towards the player
+    if (!IsTank(me) && HasRole(BOT_ROLE_RANGED) && target->GetVictim() == me)
+    {
+        // By default go to the master
+        Unit* moveTarget = master;
 
+        // Look for a tank in the master's bots
+        BotMap const* map = master->GetBotMgr()->GetBotMap();
+        for (BotMap::const_iterator itr = map->begin(); itr != map->end(); ++itr)
+            if (itr->second && (IsTank(itr->second) || IsOffTank(itr->second)))
+                moveTarget = itr->second;
+
+        pos.Relocate(moveTarget);
+        force = true;
+        return;
+    }
+    
     pos.Relocate(ppos);
     if (!me->IsWithinLOSInMap(target, VMAP::ModelIgnoreFlags::M2, LINEOFSIGHT_ALL_CHECKS))
         force = true;

--- a/src/server/game/AI/NpcBots/bot_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_ai.cpp
@@ -5443,7 +5443,17 @@ void bot_ai::CalculateAttackPos(Unit* target, Position& pos, bool& force) const
             if (itr->second && (IsTank(itr->second) || IsOffTank(itr->second)))
                 moveTarget = itr->second;
 
-        pos.Relocate(moveTarget);
+        // Decide if the bot needs to move
+        float thresholdDistance = 1.5f;
+        bool rangedBotNeedsToMove = std::abs(me->GetDistance(moveTarget)) > thresholdDistance;
+        if (rangedBotNeedsToMove)
+        {
+            // Randomise and adjust the bot's position
+            float randomModifier = irand(0, 1) ? 1.0f : -1.0f;
+            float absoluteAngle = me->GetAbsoluteAngle(moveTarget);
+            pos.Relocate(Position(moveTarget->GetPositionX() + randomModifier * thresholdDistance * std::cos(absoluteAngle), moveTarget->GetPositionY() + randomModifier * thresholdDistance * std::sin(absoluteAngle)));
+        }
+        
         force = true;
         return;
     }


### PR DESCRIPTION
## Changes Proposed:
This commit improves positioning for ranged bots which have aggro from the player's target. Previously bots would always keep a distance from their master which means they were effectively running away. With the changes proposed here, ranged bots will run to their master or to a bot tank/offtank when they get aggro - which is what you would expect a player to do. This will only be triggered if the player is targeting the creature which is attacking the ranged bot.

Overall this should improve crowd-control in dungeons and raids.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:
- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue
- [x] This pull request requires further testing. Provide steps to test your changes. If it requires any specific setup e.g multiple players please specify it as well.

1. Summon a ranged bot (and optionally a tank bot).
2. Body pull at least two creatures.
3. Allow the ranged bot to get aggro from one of the two creatures (e.g. by healing or attacking).
4. Target the creature which is now attacking the ranged bot. The ranged bot should move to the player, or to the tank bot if it was summoned in step 1.

## Known Issues and TODO List:
- [ ] Do we need to consider impact for PvP gameplay? Perhaps this bot tactic would be counter-productive in PvP.