### PR TITLE
feat(NpcBots/bot_ai): Prevent tank/off-tank bots from automatically taunting from other tanks/off-tanks

### DIFF
--- a/src/server/game/AI/NpcBots/bot_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_ai.cpp
@@ -6600,7 +6600,20 @@ Unit* bot_ai::FindDistantTauntTarget(float maxdist, bool ally) const
         return nullptr;
 
     Unit* unit = unitList.size() == 1 ? *unitList.begin() : Acore::Containers::SelectRandomContainerElement(unitList);
-    return ally ? unit->GetVictim() : unit;
+
+    Unit* victim = unit->GetVictim();
+
+    // Bots should not taunt from a tank when off-tanking
+    bool victimIsTank = IsTank(victim);
+    if (victimIsTank && IsOffTank())
+        return nullptr;
+
+    // Bots should not taunt from an off-tank when tanking
+    bool victimIsOffTank = victimIsTank && !IsOffTank();
+    if (victimIsOffTank && IsPointedOffTankingTarget(unit))
+        return nullptr;
+    
+    return ally ? victim : unit;
 }
 //Finds target for Warlock's Mana Drain
 //Returns nearby CCed unit with most mana


### PR DESCRIPTION
## Changes Proposed:
Tank/Off-tank bots currently use taunt on cooldown on any target from which they do not have aggro. This causes two issues in raids and dungeons:
- it makes crowd-control between multiple tanks very awkward as they keep taunting off each other
- it makes tanking as a player very awkward if there is a tank bot in the raid

The changes proposed here prevent tank/off-tank bots from taunting from other tanks/off-tanks as it is counter-intuitive to try and take threat from a creature which is already being tanked by someone else. This improves crowd/bot control in raids and dungeons.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

I have been testing these changes for a while in a custom server without any issues.