### PR TITLE
fix(NpcBots/bot_ai): Fixed gold looted by bots to be correctly modified by scripts and modules

### DIFF
--- a/src/server/game/AI/NpcBots/bot_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_ai.cpp
@@ -43,6 +43,7 @@
 #include "TemporarySummon.h"
 #include "Transport.h"
 #include "World.h"
+#include "ScriptMgr.h"
 /*
 NpcBot System by Trickerer (https://github.com/trickerer/Trinity-Bots; onlysuffering@gmail.com)
 Version 5.2.77a
@@ -11528,6 +11529,9 @@ void bot_ai::_autoLootCreatureGold(Creature* creature) const
     Group const* gr = master->GetGroup();
     if (!gr)
     {
+        // Modify gold in scripts/modules
+        sScriptMgr->OnBeforeLootMoney(master, loot);
+        
         master->ModifyMoney(loot->gold);
         master->UpdateAchievementCriteria(ACHIEVEMENT_CRITERIA_TYPE_LOOT_MONEY, loot->gold);
 
@@ -11545,6 +11549,9 @@ void bot_ai::_autoLootCreatureGold(Creature* creature) const
             if (p && p->IsAtGroupRewardDistance(creature))
                 players.push_back(p);
         }
+        
+        // Modify gold in scripts/modules
+        sScriptMgr->OnBeforeLootMoney(master, loot);
 
         uint32 goldPerPlayer = uint32(loot->gold / uint32(players.size()));
 


### PR DESCRIPTION
## Changes Proposed:
The gold amount looted by bots is not being adjusted for any scripts/modules as it is when a player is looting the gold.
The changes proposed here correct that.

This PR proposes changes to:
-  [x] Core (units, players, creatures, game systems).
-  [ ] Scripts (bosses, spell scripts, creature scripts).
-  [ ] Database (SAI, creatures, etc).

## Tests Performed:
This PR has been:
- [x] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.