### PR TITLE
fix(NPCBot): Resolve mount selection and party chat spam issues

### DIFF
--- a/src/server/game/AI/NpcBots/bot_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_ai.cpp
@@ -24,6 +24,7 @@
 #include "Chat.h"
 #include "DatabaseEnv.h"
 #include "DBCStores.h"
+#include "AreaDefines.h"
 #include "GameEventMgr.h"
 #include "GameGraveyard.h"
 #include "GameObjectAI.h"
@@ -6037,7 +6038,28 @@ uint32 bot_ai::_selectMountSpell() const
     {
         using MountArray = std::array<uint32, NUM_MOUNTS_PER_SPEED>;
 
-        bool can_fly = !IAmFree() ? master->CanFly() : false; //(!instt && me->GetMap()->GetEntry()->addon > 0);
+        // Proper flying capability check based on zone/map and Cold Weather Flying
+        bool can_fly = false;
+        if (!instt) // Only allow flying in non-instanced maps (except BG/Arena which are handled above)
+        {
+            uint32 virtualMap = GetVirtualMapForMapAndZone(me->GetMapId(), me->GetZoneId());
+            if (virtualMap == MAP_OUTLAND)
+            {
+                // Outland: Flying is always allowed
+                can_fly = true;
+            }
+            else if (virtualMap == MAP_NORTHREND)
+            {
+                // Northrend: Requires Cold Weather Flying (spell 54197)
+                // Check master's spell if bot has owner, or assume bots have it at appropriate level
+                if (!IAmFree())
+                    can_fly = master->HasSpell(54197);
+                else
+                    can_fly = me->GetLevel() >= 68; // Cold Weather Flying is learned at 68
+            }
+            // Eastern Kingdoms and Kalimdor: No flying (vanilla continents)
+        }
+
         bool useSlowMount = can_fly ? (me->GetLevel() < 70 || maxMountSpeed < 220) : (me->GetLevel() < minLevel100 || maxMountSpeed < 80);
 
         if (!can_fly)
@@ -6110,8 +6132,9 @@ uint32 bot_ai::_selectMountSpell() const
         }
         else //if (can_fly)
         {
+            // Druid Flight Form: 33943 (150% speed), Swift Flight Form: 40120 (280% speed)
             if (GetBotClass() == BOT_CLASS_DRUID && GetSpell(33943))
-                myMountSpellId = useSlowMount ? 33943 : GetSpell(33943);
+                myMountSpellId = useSlowMount ? 33943 : (GetSpell(40120) ? 40120 : 33943);
             else
             {
                 static const MountArray MOUNTS_150_ALLIANCE = { BOT_MOUNT_FLY_ALLIANCE_150_1, BOT_MOUNT_FLY_ALLIANCE_150_2, BOT_MOUNT_FLY_ALLIANCE_150_3 };
@@ -7662,8 +7685,9 @@ void bot_ai::OnSpellHit(Unit* caster, SpellInfo const* spell)
         if (auraname == SPELL_AURA_MOUNTED || (!spell->HasAura(SPELL_AURA_MOUNTED) && auraname == SPELL_AURA_MOD_INCREASE_FLIGHT_SPEED))
         {
             //BOT_LOG_ERROR("entities.unit", "OnSpellHit: mount on %s", me->GetName().c_str());
-            if (master->HasAuraType(SPELL_AURA_MOD_INCREASE_FLIGHT_SPEED) ||
-                master->HasAuraType(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED))
+            // Fixed: Check if the SPELL itself is a flying mount, not if master is flying
+            if (spell->HasAura(SPELL_AURA_MOD_INCREASE_FLIGHT_SPEED) ||
+                spell->HasAura(SPELL_AURA_MOD_INCREASE_MOUNTED_FLIGHT_SPEED))
             {
                 //BOT_LOG_ERROR("entities.unit", "OnSpellHit: modding flight speed");
                 UnsummonAll(false);

--- a/src/server/game/Groups/Group.cpp
+++ b/src/server/game/Groups/Group.cpp
@@ -1970,20 +1970,35 @@ void Group::SendUpdateToPlayer(ObjectGuid playerGUID, MemberSlot* slot)
 
     data << m_guid;
     data << uint32(m_counter++);                        // 3.3, value increases every time this packet gets sent
-    data << uint32(GetMembersCount() - 1);
+
+    //npcbot: Count only player members for client packet
+    // Creatures/bots remain in m_memberSlots for server-side functionality (XP, loot, buffs)
+    // but must not be sent to the client to prevent "party1 is not in your party" spam
+    uint32 clientMemberCount = 0;
+    for (member_citerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
+    {
+        if (citr->guid != slot->guid && citr->guid.IsPlayer())
+            ++clientMemberCount;
+    }
+    data << uint32(clientMemberCount);
+    //end npcbot
+
     for (member_citerator citr = m_memberSlots.begin(); citr != m_memberSlots.end(); ++citr)
     {
         if (slot->guid == citr->guid)
             continue;
 
+        //npcbot: Skip creature/bot members when sending to client
+        // Client cannot handle creature GUIDs in party and will spam error messages
+        // Bots remain in m_memberSlots for all server-side group functionality
+        if (citr->guid.IsCreature())
+            continue;
+        //end npcbot
+
         Player* member = ObjectAccessor::FindConnectedPlayer(citr->guid);
 
         uint8 onlineState = (member && !member->GetSession()->PlayerLogout()) ? MEMBER_STATUS_ONLINE : MEMBER_STATUS_OFFLINE;
         onlineState = onlineState | ((isBGGroup() || isBFGroup()) ? MEMBER_STATUS_PVP : 0);
-
-        //npcbot: bots are always online
-        onlineState |= citr->guid.IsCreature() ? 1 : 0;
-        //end npcbot
 
         data << citr->name;
         data << citr->guid;                             // guid


### PR DESCRIPTION
## Changes Proposed:

Mount Selection Improvements:
- Fixed flying mount zone detection using GetVirtualMapForMapAndZone()
- Added Cold Weather Flying (54197) requirement for Northrend
- Fixed flying mount wing animations by checking spell auras
- Corrected Druid Swift Flight Form backwards ternary logic
- Bots now properly use flying mounts in Outland and Northrend

Party Chat Fixes:
- Filtered creature GUIDs from SMSG_GROUP_LIST client packets
- Eliminated 'partyX is not in your party' spam messages
- Maintained bots in m_memberSlots for XP, loot, buffs functionality

Technical Details:
- bot_ai.cpp: Replaced master->CanFly() with zone-based detection
- bot_ai.cpp: Fixed OnSpellHit() to check spell auras not master state
- Group.cpp: Added creature GUID filter in SendUpdateToPlayer()

This PR proposes changes to:
- [x] Core (units, players, creatures, game systems).
- [x] Scripts (bosses, spell scripts, creature scripts).

## Issues Addressed:

Fixes three critical NPCBot bugs:
1. Bots using ground mounts in flying zones (Outland/Northrend)
2. Flying mount wings not animating
3. Continuous "partyX is not in your party" client spam

## SOURCE:

The changes have been validated through:
- [x] Live research (tested against WotLK 3.3.5a behavior)

## Tests Performed:

This PR has been:
- [x] Tested in-game by the author.
- [x] Tested in-game on live production server (Ineffable Community) with multiple bots in various zones. All group mechanics (XP, loot, buffs) remain fully functional.