### PR TITLE
Change specialization check from Protection to Arms for Poleaxe

### DIFF
--- a/src/server/game/AI/NpcBots/bot_warrior_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_warrior_ai.cpp
@@ -1278,7 +1278,7 @@ public:
                 if (lvl >= 20)
                     pctbonus *= 1.1f;
                 //Poleaxe Specialization: 5% additional critical damage for all attacks
-                if ((GetSpec() == BOT_SPEC_WARRIOR_PROTECTION) && lvl >= 30)
+                if ((GetSpec() == BOT_SPEC_WARRIOR_ARMS) && lvl >= 30)
                     if (Item const* weap = GetEquips(uint8(attackType)))
                         if (ItemTemplate const* proto = weap->GetTemplate())
                             if (proto->SubClass == ITEM_SUBCLASS_WEAPON_AXE || proto->SubClass == ITEM_SUBCLASS_WEAPON_AXE2 ||


### PR DESCRIPTION
Fixed a likely Arms bug in the damage multiplier area: the melee-spell crit-damage check for Poleaxe Specialization was checking `BOT_SPEC_WARRIOR_PROTECTION`