### PR TITLE
Implement pre-pull healing for Druid bot AI

### DIFF
--- a/src/server/game/AI/NpcBots/bot_druid_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_druid_ai.cpp
@@ -185,7 +185,8 @@ enum DruidSpecial
     INFECTED_WOUNDS_EFFECT              = 58181,//rank 3
     PRIMAL_FURY_EFFECT_ENERGIZE         = 16959,//5 rage
 
-    FORCE_OF_NATURE_1                   = 33831 //not casted
+    FORCE_OF_NATURE_1                   = 33831, //not casted
+    PRE_PULL_HEAL_TIMER                 = 1500
 };
 
 static const std::vector<uint32> Druid_spells_damage
@@ -562,6 +563,8 @@ public:
                 CureGroup(GetSpell(CURE_POISON_1), diff);
                 CureGroup(GetSpell(REMOVE_CURSE_1), diff);
             }
+
+            DoPrePullTankHealing(diff);
 
             if (ProcessImmediateNonAttackTarget())
                 return;
@@ -1347,6 +1350,80 @@ public:
                 {
                     if (doCast(me, GetSpell(TRAVEL_FORM_1)))
                         return;
+                }
+            }
+        }
+
+        void DoPrePullTankHealing(uint32 diff)
+        {
+            if (prePullHealTimer > diff || GC_Timer > diff)
+                return;
+            if (me->IsInCombat() || master->IsInCombat() || me->IsMounted() || me->GetVehicle() ||
+                !HasRole(BOT_ROLE_HEAL) || HasRole(BOT_ROLE_TANK))
+                return;
+            if (IAmFree() || IsCasting())
+                return;
+            if (master->GetBotMgr()->IsPartyInCombat(false))
+                return;
+
+            prePullHealTimer = PRE_PULL_HEAL_TIMER;
+
+            if (me->GetPowerType() != POWER_MANA || GetManaPCT(me) < 55)
+                return;
+
+            if (_form != BOT_STANCE_NONE && _form != DRUID_TREE_FORM)
+                if (!removeShapeshiftForm())
+                    return;
+
+            for (Unit* member : BotMgr::GetAllGroupMembers(master))
+            {
+                if (!member || member == me || !member->IsAlive() || me->GetMap() != member->FindMap())
+                    continue;
+                if (member->isPossessed() || member->IsCharmed())
+                    continue;
+                if (member->IsInCombat() || !member->getAttackers().empty())
+                    continue;
+                if (!IsTank(member))
+                    continue;
+                if (me->GetDistance(member) > 40.f)
+                    continue;
+
+                Unit* nearby = member->SelectNearbyTarget(nullptr, 45.f);
+                if (!nearby || !nearby->IsAlive() || !nearby->IsInWorld() || nearby->FindMap() != me->GetMap() ||
+                    !nearby->IsCreature() || !me->IsValidAttackTarget(nearby))
+                    continue;
+
+                if (uint32 REJUVENATION = GetSpell(REJUVENATION_1))
+                {
+                    if (IsSpellReady(REJUVENATION_1, diff) &&
+                        !member->GetAuraEffect(SPELL_AURA_PERIODIC_HEAL, SPELLFAMILY_DRUID, 0x10, 0x0, 0x0, me->GetGUID()))
+                    {
+                        if (doCast(member, REJUVENATION))
+                            return;
+                    }
+                }
+
+                if (uint32 REGROWTH = GetSpell(REGROWTH_1))
+                {
+                    if (IsSpellReady(REGROWTH_1, diff) &&
+                        !member->GetAuraEffect(SPELL_AURA_PERIODIC_HEAL, SPELLFAMILY_DRUID, 0x40, 0x0, 0x0, me->GetGUID()))
+                    {
+                        if (doCast(member, REGROWTH))
+                            return;
+                    }
+                }
+
+                if (uint32 LIFEBLOOM = GetSpell(LIFEBLOOM_1))
+                {
+                    if (IsSpellReady(LIFEBLOOM_1, diff))
+                    {
+                        AuraEffect const* bloom = member->GetAuraEffect(SPELL_AURA_PERIODIC_HEAL, SPELLFAMILY_DRUID, 0x0, 0x10, 0x0, me->GetGUID());
+                        if (!bloom || bloom->GetBase()->GetStackAmount() < 3 || bloom->GetBase()->GetDuration() < 3500)
+                        {
+                            if (doCast(member, LIFEBLOOM))
+                                return;
+                        }
+                    }
                 }
             }
         }
@@ -2610,6 +2687,7 @@ public:
 
             hibery = false;
             hiberyCheckTimer = 0;
+            prePullHealTimer = 0;
 
             me->SetMaxPower(POWER_ENERGY, 100); //for regeneration
             rageLossMult = sWorld->getRate(RATE_POWER_RAGE_LOSS);
@@ -2624,6 +2702,7 @@ public:
             if (ragetimer > diff)                   ragetimer -= diff;
 
             if (hiberyCheckTimer > diff)            hiberyCheckTimer -= diff;
+            if (prePullHealTimer > diff)            prePullHealTimer -= diff;
         }
 
         void InitPowers() override
@@ -2956,6 +3035,7 @@ public:
 /*Misc*/uint32 ragetimer;
         bool hibery;
         uint32 hiberyCheckTimer;
+        uint32 prePullHealTimer;
 /*Misc*/int32 rage, energy;
 
         using HealMap = std::unordered_map<uint32 /*baseId*/, int32 /*amount*/>;


### PR DESCRIPTION
`DoPrePullTankHealing(uint32 diff)` is now `void`. The call now sits after `CureGroup(...)` and before `ProcessImmediateNonAttackTarget():`

```
DoPrePullTankHealing(diff);

if (ProcessImmediateNonAttackTarget())
    return;
```
I moved the timer into enum DruidSpecial (frankly,  I don't know where you actually want this. It seems kind of odd in DruidSpecial):

```
PRE_PULL_HEAL_TIMER                 = 1500
```
I removed the helper lambdas, removed self/master hostile scans, removed the temp-bot check, and changed tank detection to:

```
if (!IsTank(member))
    continue;
```

The method now does only one hostile scan per candidate tank:

```
Unit* nearby = member->SelectNearbyTarget(nullptr, 45.f);
```

And the member checks are ordered the way you requested:

```
if (!member || member == me || !member->IsAlive() || me->GetMap() != member->FindMap())
if (member->isPossessed() || member->IsCharmed())
if (member->IsInCombat() || !member->getAttackers().empty())
if (!IsTank(member))
if (me->GetDistance(member) > 40.f)
```

You may want to consider adjusting ranges, of course.