### PR TITLE
Fix NPCBot Dungeon Finder requeue after completed dungeon

### DIFF
--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -44,7 +44,6 @@
 //npcbot
 #include "botconfig.h"
 #include "botmgr.h"
-#include "Chat.h"
 #include "Creature.h"
 //end npcbot
 

--- a/src/server/game/DungeonFinding/LFGMgr.cpp
+++ b/src/server/game/DungeonFinding/LFGMgr.cpp
@@ -613,7 +613,34 @@ namespace lfg
         LfgJoinResultData joinData;
         LfgGuidSet players;
         uint32 rDungeonId = 0;
+
+        bool hasNpcBotMember = false;
+
+        if (grp)
+        {
+            for (Group::MemberSlot const& slot : grp->GetMemberSlots())
+            {
+                if (slot.guid.IsCreature())
+                {
+                    hasNpcBotMember = true;
+                    break;
+                }
+            }
+        }
+
         bool isContinue = grp && grp->isLFGGroup() && GetState(gguid) != LFG_STATE_FINISHED_DUNGEON;
+
+        // NPCBot groups can remain flagged as an LFG group after a completed dungeon even when
+        // the player is trying to start a fresh queue. In that stale state, the old continue
+        // logic replaces the player's new dungeon selection with GetDungeon(gguid), which may
+        // be 0 or stale, causing LFG_JOIN_DUNGEON_INVALID.
+        if (isContinue && hasNpcBotMember)
+        {
+            uint32 currentDungeon = GetDungeon(gguid);
+
+            if (!currentDungeon || dungeons.find(currentDungeon) == dungeons.end())
+                isContinue = false;
+        }
 
         if (grp && (grp->isBGGroup() || grp->isBFGroup()))
             return;
@@ -779,7 +806,7 @@ namespace lfg
                                     break;
                                 }
 
-                                if (ObjectAccessor::GetCreature(*plrg, bguid))
+                                if (bot)
                                 {
                                     ++memberCount;
                                     players.insert(bguid);
@@ -836,7 +863,7 @@ namespace lfg
             return;
 
          // Do not allow to change dungeon in the middle of a current dungeon
-        if (!isRaid && isContinue && grp->GetMembersCount() == 5)
+        if (!isRaid && isContinue && grp->GetMembersCount() == 5 && !hasNpcBotMember)
         {
             dungeons.clear();
             dungeons.insert(GetDungeon(gguid));


### PR DESCRIPTION
Fixes an issue where players grouped with NPCBots could be unable to queue for another dungeon after completing a Dungeon Finder run without regrouping. This also allows you to continue a half-completed dungeon later between sessions if you did not complete said dungeon in the same group.

NPCBot groups can remain flagged as an LFG group after completion, causing JoinLfg to treat the next queue attempt as a “continue current dungeon” request. That stale continuation path can replace the player’s new dungeon selection with the group’s old dungeon ID, which may be stale or invalid, resulting in errors like:

`One or more players is ineligible`

or:

`One or more dungeons was not valid`

This patch detects NPCBot groups and avoids applying the normal full-group continuation rejection when the player is starting a fresh queue. It also keeps NPCBot member validation based on the bot pointer from the owner’s BotMgr, rather than requiring ObjectAccessor::GetCreature to resolve the bot at that exact moment.

Testing:

Tested with a player grouped with NPCBots through Dungeon Finder:

1. Queue with NPCBots.
2. Complete the dungeon.
3. Queue again without leaving or reforming the group.
4. Confirmed the next queue works correctly.

As a side note, not sure if you want me to use something other than `if (slot.guid.IsCreature())`.

I thought about doing:
```
bool hasNpcBotMember = false;

if (grp)
{
    for (Group::MemberSlot const& slot : grp->GetMemberSlots())
    {
        if (!slot.guid.IsCreature())
            continue;

        Creature const* bot = BotDataMgr::FindBot(slot.guid.GetEntry());
        if (bot && bot->IsNPCBot())
        {
            hasNpcBotMember = true;
            break;
        }
    }
}
```
If that's what you prefer. Would require `#include "botdatamgr.h"`, of course. 

EDIT: For manual dungeon rentry (i.e. through a portal), additional changes will likely need to be made. I just need to do extra testing and hunt them down if so.