### PR TITLE
Add bonus damage calculations for shaman spells

### DIFF
--- a/src/server/game/AI/NpcBots/bot_shaman_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_shaman_ai.cpp
@@ -1510,6 +1510,15 @@ public:
             //Call of Flame (part 2): 6% bonus damage for Lava burst
             if (lvl >= 15 && spellId == GetSpell(LAVA_BURST_1))
                 pctbonus += 0.06f;
+            //Glyph of Lightning Bolt: 4% bonus damage for Lightning Bolt
+            //Glyph of Lava: 10% bonus damage for Lava Burst
+            if (GetSpec() == BOT_SPEC_SHAMAN_ELEMENTAL)
+            {
+                if (spellId == GetSpell(LIGHTNING_BOLT_1))
+                    pctbonus += 0.04f;
+                else if (spellId == GetSpell(LAVA_BURST_1))
+                    pctbonus += 0.10f;
+            }
             //Storm, Earth and fire (part 3): 60% bonus damage for Flame Shock (periodic damage in fact but who cares?)
             if ((GetSpec() == BOT_SPEC_SHAMAN_ELEMENTAL) && lvl >= 40 && spellId == GetSpell(FLAME_SHOCK_1))
                 pctbonus += 0.6f;

--- a/src/server/game/AI/NpcBots/bot_shaman_ai.cpp
+++ b/src/server/game/AI/NpcBots/bot_shaman_ai.cpp
@@ -1511,14 +1511,11 @@ public:
             if (lvl >= 15 && spellId == GetSpell(LAVA_BURST_1))
                 pctbonus += 0.06f;
             //Glyph of Lightning Bolt: 4% bonus damage for Lightning Bolt
+            if ((GetSpec() == BOT_SPEC_SHAMAN_ELEMENTAL) && lvl >= 15 && spellId == GetSpell(LIGHTNING_BOLT_1))
+                pctbonus += 0.04f;
             //Glyph of Lava: 10% bonus damage for Lava Burst
-            if (GetSpec() == BOT_SPEC_SHAMAN_ELEMENTAL)
-            {
-                if (spellId == GetSpell(LIGHTNING_BOLT_1))
-                    pctbonus += 0.04f;
-                else if (spellId == GetSpell(LAVA_BURST_1))
-                    pctbonus += 0.10f;
-            }
+            if ((GetSpec() == BOT_SPEC_SHAMAN_ELEMENTAL) && lvl >= 66 && spellId == GetSpell(LAVA_BURST_1))
+                pctbonus += 0.10f;
             //Storm, Earth and fire (part 3): 60% bonus damage for Flame Shock (periodic damage in fact but who cares?)
             if ((GetSpec() == BOT_SPEC_SHAMAN_ELEMENTAL) && lvl >= 40 && spellId == GetSpell(FLAME_SHOCK_1))
                 pctbonus += 0.6f;


### PR DESCRIPTION
It looks like the bot already bakes in several talent/glyph-style passive damage bonuses through ApplyClassDamageMultiplierSpell, but Elemental is missing two standard WotLK damage glyph effects:

Glyph of Lightning Bolt: +4% Lightning Bolt damage
Glyph of Lava: +10% Lava Burst damage

I added them directly to the existing passive multiplier path, gated to Elemental spec only, so Enhancement Maelstrom casts and Restoration filler casts do not inherit the Elemental glyph package.