### PR TITLE
Prevent Call of the Beast from affecting NPCBots

### DIFF
--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
@@ -894,17 +894,18 @@ class spell_call_of_the_beast : public SpellScript
         return ValidateSpellInfo({ SPELL_FIXATE });
     }
 
-    void HandleEffect(SpellEffIndex effIndex)
+    void HandleEffect(SpellEffIndex /*effIndex*/)
     {
-        Unit* target = GetHitUnit();
-        if (!target)
-            return;
-    
-        if (target->IsNPCBotOrPet())
+        //npcbot
+        if (GetHitUnit()->IsNPCBotOrPet())
         {
-            PreventHitDefaultEffect(effIndex);
+            PreventHitDefaultEffect(EFFECT_0);
             return;
         }
+        //end npcbot
+
+        GetHitUnit()->CastSpell(GetHitUnit(), SPELL_FIXATE, true);
+    }
 
     void Register() override
     {

--- a/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
+++ b/src/server/scripts/EasternKingdoms/ZulAman/zulaman.cpp
@@ -894,10 +894,17 @@ class spell_call_of_the_beast : public SpellScript
         return ValidateSpellInfo({ SPELL_FIXATE });
     }
 
-    void HandleEffect(SpellEffIndex /*effIndex*/)
+    void HandleEffect(SpellEffIndex effIndex)
     {
-        GetHitUnit()->CastSpell(GetHitUnit(), SPELL_FIXATE, true);
-    }
+        Unit* target = GetHitUnit();
+        if (!target)
+            return;
+    
+        if (target->IsNPCBotOrPet())
+        {
+            PreventHitDefaultEffect(effIndex);
+            return;
+        }
 
     void Register() override
     {


### PR DESCRIPTION
Call of the Beast now skips NPCBots and bot pets so the Zul'Aman beast-tamer mechanic does not force hired bots to fixate their owner.

This preserves normal behavior for player targets.